### PR TITLE
Tests to download, decompress and mirror raw files from NCBI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ project/target/
 .idea*
 .vscode*
 /.gtm/
+
+# Test data
+ncbi-data/

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
 name := "db.ncbitaxonomy"
 organization := "ohnosequences"
 description := "NCBI Taxonomy data organized and mirrored at S3"
-

--- a/deps.sbt
+++ b/deps.sbt
@@ -1,3 +1,7 @@
 libraryDependencies ++= Seq(
   "ohnosequences" %% "aws-scala-tools" % "0.20.0"
+) ++ testDependencies
+
+val testDependencies = Seq(
+  "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )

--- a/src/main/scala/data.scala
+++ b/src/main/scala/data.scala
@@ -4,6 +4,9 @@ import ohnosequences.awstools.s3._ // S3{Folder,Object} and s3"" string creation
 
 package object ncbitaxonomy {
 
+  private[ncbitaxonomy] type +[A, B] =
+    Either[A, B]
+
   val sourceFile: java.net.URI =
     new java.net.URI("ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz")
 

--- a/src/main/scala/data.scala
+++ b/src/main/scala/data.scala
@@ -1,11 +1,14 @@
 package ohnosequences.db
 
-import ohnosequences.awstools.s3._
+import ohnosequences.awstools.s3._ // S3{Folder,Object} and s3"" string creation
 
 package object ncbitaxonomy {
 
+  val sourceFile: java.net.URI =
+    new java.net.URI("ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz")
+
   val version: String =
-    "???"
+    "0.0.1"
 
   val s3Prefix: S3Folder =
     s3"resources.ohnosequences.com" /

--- a/src/test/scala/fileUtils.scala
+++ b/src/test/scala/fileUtils.scala
@@ -55,4 +55,16 @@ case object utils {
       case scala.util.Success(s) => Some(s3Object)
       case scala.util.Failure(e) => None
     }
+
+  /**
+    * Returns `Some(directory)` if it was possible to create all directories in `directory` (or if they already existed); `None` otherwise.
+    */
+  def createDirectory(directory: File): Option[File] =
+    if (!directory.exists)
+      if (directory.mkdirs())
+        Some(directory)
+      else
+        None
+    else
+      Some(directory)
 }

--- a/src/test/scala/fileUtils.scala
+++ b/src/test/scala/fileUtils.scala
@@ -1,8 +1,20 @@
 package ohnosequences.db.ncbitaxonomy.test
 
+import ohnosequences.db.ncbitaxonomy.+
 import sys.process._ // System process execution: !
 import ohnosequences.awstools.s3, s3.S3Object
 import java.io.File
+
+sealed trait Error {
+  val msg: String
+}
+
+case object Error {
+  final case class Download(val msg: String)    extends Error
+  final case class Upload(val msg: String)      extends Error
+  final case class Extract(val msg: String)     extends Error
+  final case class DirCreation(val msg: String) extends Error
+}
 
 case object utils {
 
@@ -10,23 +22,27 @@ case object utils {
     * Returns `Some(file)` if the download from `uri` to `file`
     * succeeded, `None` otherwise.
     */
-  def downloadFrom(uri: java.net.URI, file: File): Option[File] = {
+  def downloadFrom(uri: java.net.URI, file: File): Error.Download + File = {
     val command = s"wget ${uri.toString} -O ${file.getCanonicalPath}"
     val result  = command !
 
     if (result == 0)
-      Some(file)
+      Right(file)
     else
-      None
+      Left(Error.Download(s"Error downloading $uri to $file."))
   }
 
   /**
     * Returns `Some(outputDir)` if the extraction from `input` into `outputDir`
     * succeeded, `None` otherwise.
     */
-  def uncompressAndExtractTo(input: File, outputDir: File): Option[File] =
+  def uncompressAndExtractTo(input: File,
+                             outputDir: File): Error.Extract + File =
     if (!outputDir.isDirectory)
-      None
+      Left(
+        Error.Extract(
+          s"Error extracting $input into directory $outputDir: $outputDir is not a directory.")
+      )
     else {
       val command =
         s"gzip -c -d ${input.getCanonicalPath}" #|
@@ -35,16 +51,19 @@ case object utils {
       val result = command !
 
       if (result == 0)
-        Some(outputDir)
+        Right(outputDir)
       else
-        None
+        Left(
+          Error.Extract(
+            s"Error extracting $input into directory $outputDir: the command finished with errors.")
+        )
     }
 
   /**
     * Returns `Some(s3Object)` if the upload from `file` to `s3Object`
     * succeeded, `None` otherwise.
     */
-  def uploadTo(file: File, s3Object: S3Object): Option[S3Object] =
+  def uploadTo(file: File, s3Object: S3Object): Error.Upload + S3Object =
     scala.util.Try {
       s3.defaultClient.putObject(
         s3Object.bucket,
@@ -52,19 +71,21 @@ case object utils {
         file
       )
     } match {
-      case scala.util.Success(s) => Some(s3Object)
-      case scala.util.Failure(e) => None
+      case scala.util.Success(s) =>
+        Right(s3Object)
+      case scala.util.Failure(e) =>
+        Left(Error.Upload(s"Error uploading$file to $s3Object: ${e.toString}."))
     }
 
   /**
     * Returns `Some(directory)` if it was possible to create all directories in `directory` (or if they already existed); `None` otherwise.
     */
-  def createDirectory(directory: File): Option[File] =
+  def createDirectory(directory: File): Error.DirCreation + File =
     if (!directory.exists)
       if (directory.mkdirs())
-        Some(directory)
+        Right(directory)
       else
-        None
+        Left(Error.DirCreation(s"Error creating directory $directory."))
     else
-      Some(directory)
+      Right(directory)
 }

--- a/src/test/scala/fileUtils.scala
+++ b/src/test/scala/fileUtils.scala
@@ -1,0 +1,58 @@
+package ohnosequences.db.ncbitaxonomy.test
+
+import sys.process._ // System process execution: !
+import ohnosequences.awstools.s3, s3.S3Object
+import java.io.File
+
+case object utils {
+
+  /**
+    * Returns `Some(file)` if the download from `uri` to `file`
+    * succeeded, `None` otherwise.
+    */
+  def downloadFrom(uri: java.net.URI, file: File): Option[File] = {
+    val command = s"wget ${uri.toString} -O ${file.getCanonicalPath}"
+    val result  = command !
+
+    if (result == 0)
+      Some(file)
+    else
+      None
+  }
+
+  /**
+    * Returns `Some(outputDir)` if the extraction from `input` into `outputDir`
+    * succeeded, `None` otherwise.
+    */
+  def uncompressAndExtractTo(input: File, outputDir: File): Option[File] =
+    if (!outputDir.isDirectory)
+      None
+    else {
+      val command =
+        s"gzip -c -d ${input.getCanonicalPath}" #|
+          s"tar xf - -C ${outputDir.getCanonicalPath}"
+
+      val result = command !
+
+      if (result == 0)
+        Some(outputDir)
+      else
+        None
+    }
+
+  /**
+    * Returns `Some(s3Object)` if the upload from `file` to `s3Object`
+    * succeeded, `None` otherwise.
+    */
+  def uploadTo(file: File, s3Object: S3Object): Option[S3Object] =
+    scala.util.Try {
+      s3.defaultClient.putObject(
+        s3Object.bucket,
+        s3Object.key,
+        file
+      )
+    } match {
+      case scala.util.Success(s) => Some(s3Object)
+      case scala.util.Failure(e) => None
+    }
+}

--- a/src/test/scala/mirror.scala
+++ b/src/test/scala/mirror.scala
@@ -1,0 +1,52 @@
+package ohnosequences.db.ncbitaxonomy.test
+
+import ohnosequences.db.ncbitaxonomy.{names, nodes, sourceFile}
+import ohnosequences.db.ncbitaxonomy.test.utils.{
+  downloadFrom,
+  uncompressAndExtractTo,
+  uploadTo
+}
+import ohnosequences.test.ReleaseOnlyTest
+import ohnosequences.awstools.s3.S3Object
+import org.scalatest.FunSuite
+import java.io.File
+
+class Mirror extends FunSuite {
+  test("Mirror data from NCBI FTP into ohnosequences S3", ReleaseOnlyTest) {
+    val directory = new File("/opt/data/")
+
+    val localFile = directory.toPath.resolve("taxdump.tar.gz").toFile
+    val namesFile = directory.toPath.resolve("names.dmp").toFile
+    val nodesFile = directory.toPath.resolve("nodes.dmp").toFile
+
+    // Retrieve original archived, compressed file from NCBI FTP
+    downloadFromOrFail(sourceFile, localFile)
+
+    // Uncompress and extract the archive file to get names.dmp and nodes.dmp
+    uncompressAndExtractToOrFail(localFile, directory)
+
+    // Upload nodes.dmp and names.dmp to their respective S3 locations
+    uploadToOrFail(namesFile, names)
+    uploadToOrFail(nodesFile, nodes)
+  }
+
+  def getOrFail[X](msg: String): Option[X] => X =
+    _.fold(fail(msg)) { x =>
+      x
+    }
+
+  def downloadFromOrFail(uri: java.net.URI, file: File) =
+    getOrFail(s"Error downloading $uri to $file") {
+      downloadFrom(uri, file)
+    }
+
+  def uncompressAndExtractToOrFail(input: File, outputDir: File) =
+    getOrFail(s"Error extracting $input into directory $outputDir") {
+      uncompressAndExtractTo(input, outputDir)
+    }
+
+  def uploadToOrFail(file: File, s3Object: S3Object) =
+    getOrFail(s"Error uploading $file to $s3Object") {
+      uploadTo(file, s3Object)
+    }
+}

--- a/src/test/scala/mirror.scala
+++ b/src/test/scala/mirror.scala
@@ -1,5 +1,6 @@
 package ohnosequences.db.ncbitaxonomy.test
 
+import ohnosequences.db.ncbitaxonomy.+
 import ohnosequences.db.ncbitaxonomy.{names, nodes, sourceFile}
 import ohnosequences.db.ncbitaxonomy.test.utils.{
   createDirectory,
@@ -34,28 +35,29 @@ class Mirror extends FunSuite {
     uploadToOrFail(nodesFile, nodes)
   }
 
-  def getOrFail[X](msg: String): Option[X] => X =
-    _.fold(fail(msg)) { x =>
-      x
+  def getOrFail[E <: Error, X]: E + X => X =
+    _ match {
+      case Right(x) => x
+      case Left(e)  => fail(e.msg)
     }
 
   def downloadFromOrFail(uri: java.net.URI, file: File) =
-    getOrFail(s"Error downloading $uri to $file") {
+    getOrFail {
       downloadFrom(uri, file)
     }
 
   def uncompressAndExtractToOrFail(input: File, outputDir: File) =
-    getOrFail(s"Error extracting $input into directory $outputDir") {
+    getOrFail {
       uncompressAndExtractTo(input, outputDir)
     }
 
   def uploadToOrFail(file: File, s3Object: S3Object) =
-    getOrFail(s"Error uploading $file to $s3Object") {
+    getOrFail {
       uploadTo(file, s3Object)
     }
 
   def createDirectoryOrFail(directory: File) =
-    getOrFail(s"Error creating directory $directory.") {
+    getOrFail {
       createDirectory(directory)
     }
 }

--- a/src/test/scala/mirror.scala
+++ b/src/test/scala/mirror.scala
@@ -13,7 +13,7 @@ import java.io.File
 
 class Mirror extends FunSuite {
   test("Mirror data from NCBI FTP into ohnosequences S3", ReleaseOnlyTest) {
-    val directory = new File("/opt/data/")
+    val directory = new File("./ncbi-data/")
 
     val localFile = directory.toPath.resolve("taxdump.tar.gz").toFile
     val namesFile = directory.toPath.resolve("names.dmp").toFile

--- a/src/test/scala/mirror.scala
+++ b/src/test/scala/mirror.scala
@@ -2,6 +2,7 @@ package ohnosequences.db.ncbitaxonomy.test
 
 import ohnosequences.db.ncbitaxonomy.{names, nodes, sourceFile}
 import ohnosequences.db.ncbitaxonomy.test.utils.{
+  createDirectory,
   downloadFrom,
   uncompressAndExtractTo,
   uploadTo
@@ -18,6 +19,9 @@ class Mirror extends FunSuite {
     val localFile = directory.toPath.resolve("taxdump.tar.gz").toFile
     val namesFile = directory.toPath.resolve("names.dmp").toFile
     val nodesFile = directory.toPath.resolve("nodes.dmp").toFile
+
+    // Create the relative directory ./data
+    createDirectoryOrFail(directory)
 
     // Retrieve original archived, compressed file from NCBI FTP
     downloadFromOrFail(sourceFile, localFile)
@@ -48,5 +52,10 @@ class Mirror extends FunSuite {
   def uploadToOrFail(file: File, s3Object: S3Object) =
     getOrFail(s"Error uploading $file to $s3Object") {
       uploadTo(file, s3Object)
+    }
+
+  def createDirectoryOrFail(directory: File) =
+    getOrFail(s"Error creating directory $directory.") {
+      createDirectory(directory)
     }
 }


### PR DESCRIPTION
We need to:

- [x] Download `ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz`.
- [x] Extract its contents.
- [x] Upload `nodes.dmp` to `ohnosequences.db.ncbitaxonomy.nodes` S3 object.
- [x] Upload `names.dmp` to `ohnosequences.db.ncbitaxonomy.names` S3 object.

The code here will be quite similar to the one in `db.rnacentral`.

@eparejatobes, one question: should we implement this as a bundle, like in `db.rnacentral`?

needed-by ohnosequences/db.taxonomy#5 