### PR TITLE
Versions

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,5 +1,14 @@
 # NCBI Taxonomy
 
+Mirror of NCBI Taxonomy data. The mirrored files are at
+
+```
+s3://resources.ohnosequences.com/db/ncbitaxonomy/<version>/names.dmp
+s3://resources.ohnosequences.com/db/ncbitaxonomy/<version>/names.dmp
+```
+
+where `<version>` match one of the [releases of this repository][db.ncbitaxonomy-releases].
+
 ## Data Source
 
 All input data is under `ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/`. We are mostly interested in `taxdump*` files, for which there's a [readme][taxdump-readme]. We need to get the contents of [taxdump.tar.gz][taxdump-archive]; after extracing we should see
@@ -100,5 +109,16 @@ Sample rows:
 24      |       strain Hammer 95        |               |       type material   |
 ```
 
+## Data Versioning
+
+The data source from NCBI FTP (see [Data Source](#data-source)) has no versions as far as we know ---in their [website][website-guide], they affirm that "New taxa are added to the Taxonomy database as data are deposited for them"---.
+
+However, this mirror will be versioned, storing the date of creation of each version as a metadata of the release. Further checks of each version will be done when needed (e.g., see [db.rna16s.assignments/#1][db.rna16s.assignments-issue-1].
+
+The files on each release of this repo are consistent (i.e., the files `nodes.dmp` and `names.dmp` refer to the same information); as the source data is extracted from one single archived file (and we assume the archived files released by NCBI are self-consistent).
+
 [taxdump-readme]: ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump_readme.txt
 [taxdump-archive]: ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdump.tar.gz
+[website-guide]: https://www.ncbi.nlm.nih.gov/guide/taxonomy/
+[db.rna16s.assignments-issue-1]: https://github.com/ohnosequences/db.rna16s.assignments/issues/1
+[db.ncbitaxonomy-releases]: https://github.com/ohnosequences/db.ncbitaxonomy/releases

--- a/generic.sbt
+++ b/generic.sbt
@@ -56,3 +56,13 @@ bucketSuffix := "era7.com"
 ////////////////////////////////////////////////////////////////////////////////
 
 // overriding!
+
+// sbt-build-info stuff; basically used to generate build time value
+lazy val root = (project in file(".")).
+  enablePlugins(BuildInfoPlugin).
+  settings(
+    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
+    buildInfoPackage := "db.ncbitaxonomy"
+  )
+
+buildInfoOptions += BuildInfoOption.BuildTime

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,6 @@ resolvers ++= Seq(
   Resolver.jcenterRepo
 )
 
-addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
-addSbtPlugin("ohnosequences" % "nice-sbt-settings" % "0.9.0")
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt"      % "1.15")
+addSbtPlugin("ohnosequences"  % "nice-sbt-settings" % "0.9.0")
+addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"     % "0.8.0")

--- a/src/test/scala/fileUtils.scala
+++ b/src/test/scala/fileUtils.scala
@@ -19,8 +19,8 @@ case object Error {
 case object utils {
 
   /**
-    * Returns `Some(file)` if the download from `uri` to `file`
-    * succeeded, `None` otherwise.
+    * Returns `Right(file)` if the download from `uri` to `file`
+    * succeeded, `Left(Error.Download(msg))` otherwise.
     */
   def downloadFrom(uri: java.net.URI, file: File): Error.Download + File = {
     val command = s"wget ${uri.toString} -O ${file.getCanonicalPath}"
@@ -33,15 +33,17 @@ case object utils {
   }
 
   /**
-    * Returns `Some(outputDir)` if the extraction from `input` into `outputDir`
-    * succeeded, `None` otherwise.
+    * Returns `Right(outputDir)` if the extraction from `input` into `outputDir`
+    * succeeded, ``Left(Error.Extract(msg))`` otherwise.
     */
   def uncompressAndExtractTo(input: File,
                              outputDir: File): Error.Extract + File =
     if (!outputDir.isDirectory)
       Left(
         Error.Extract(
-          s"Error extracting $input into directory $outputDir: $outputDir is not a directory.")
+          s"Error extracting $input into directory $outputDir: " +
+            s"$outputDir is not a directory."
+        )
       )
     else {
       val command =
@@ -55,13 +57,15 @@ case object utils {
       else
         Left(
           Error.Extract(
-            s"Error extracting $input into directory $outputDir: the command finished with errors.")
+            s"Error extracting $input into directory $outputDir: " +
+              s"the command finished with errors."
+          )
         )
     }
 
   /**
-    * Returns `Some(s3Object)` if the upload from `file` to `s3Object`
-    * succeeded, `None` otherwise.
+    * Returns `Right(s3Object)` if the upload from `file` to `s3Object`
+    * succeeded, ``Left(Error.Upload(msg))`` otherwise.
     */
   def uploadTo(file: File, s3Object: S3Object): Error.Upload + S3Object =
     scala.util.Try {
@@ -78,7 +82,9 @@ case object utils {
     }
 
   /**
-    * Returns `Some(directory)` if it was possible to create all directories in `directory` (or if they already existed); `None` otherwise.
+    * Returns `Right(directory)` if it was possible to create all directories
+    * in `directory` (or if they already existed);
+    * `Left(Error.DirCreation(msg))` otherwise.
     */
   def createDirectory(directory: File): Error.DirCreation + File =
     if (!directory.exists)


### PR DESCRIPTION
NCBI taxonomy data has no versioning conventions as far as we know, but we should definitely keep some kind of versioning.

(Dummy) proposal: we can mark this first release, with the current files from NCBI FTP, as v1.0 and bump it whenever we (manually?) see there are important updtes to the taxonomy files.