### PR TITLE
Dump trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ project/plugins/project/
 # data folders
 data/in/
 data/out/
+data/tests/
 
 project/project/
 project/target/

--- a/deps.sbt
+++ b/deps.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
-  "ohnosequences" %% "s3"      % "0.1.0-4-gaa153b0",
+  "ohnosequences" %% "s3"      % "0.1.0-11-ge66487e",
   "ohnosequences" %% "forests" % "0.1.0"
 ) ++ testDependencies
 

--- a/deps.sbt
+++ b/deps.sbt
@@ -1,6 +1,6 @@
 libraryDependencies ++= Seq(
-  "ohnosequences" %% "s3"      % "0.1.0-11-ge66487e",
-  "ohnosequences" %% "forests" % "0.1.0"
+  "ohnosequences" %% "s3"      % "0.1.0-11-ge66487e-SNAPSHOT",
+  "ohnosequences" %% "forests" % "0.1.0-2-gdbfdd11-SNAPSHOT"
 ) ++ testDependencies
 
 val testDependencies = Seq(

--- a/src/main/scala/io.scala
+++ b/src/main/scala/io.scala
@@ -197,7 +197,7 @@ case object io {
   def readTaxTreeFromFiles(
       dataFile: File,
       shapeFile: File
-  ): FileError + (SerializationError + TaxTree) = {
+  ): (FileError + SerializationError) + TaxTree = {
     val taxNodeRegex = "TaxNode\\((\\d+),([a-zA-Z]*),(.*)\\)".r
 
     val fromString: String => Option[TaxNode] = { str =>
@@ -238,7 +238,18 @@ case object io {
     // If error ocurred in the data file retrieval, project to left
     // If error ocurred in the shape file retrieval, it can be either
     // a non-existent file or a SerializationError
-    treeResult.fold(dataError => Left(dataError), shapeResult => shapeResult)
+    treeResult.fold(
+      dataError => Left(Left(dataError)),
+      shapeResult =>
+        shapeResult.fold(
+          shapeError => Left(Left(shapeError)),
+          treeResult =>
+            treeResult.fold(
+              serializationError => Left(Right(serializationError)),
+              tree => Right(tree)
+          )
+      )
+    )
   }
 
 }

--- a/src/main/scala/io.scala
+++ b/src/main/scala/io.scala
@@ -213,6 +213,7 @@ case object io {
       }
     }
 
+    // Tries to deserialize the tree from the files
     val treeResult = read.withLines(dataFile) { dataLines =>
       val data = dataLines.zipWithIndex
 
@@ -234,6 +235,9 @@ case object io {
       }
     }
 
+    // If error ocurred in the data file retrieval, project to left
+    // If error ocurred in the shape file retrieval, it can be either
+    // a non-existent file or a SerializationError
     treeResult.fold(dataError => Left(dataError), shapeResult => shapeResult)
   }
 

--- a/src/main/scala/io.scala
+++ b/src/main/scala/io.scala
@@ -1,12 +1,15 @@
 package ohnosequences.db.ncbitaxonomy
 
 import ohnosequences.forests.{Tree, io => treeIO, IOError => SerializationError}
+import treeIO.{Serialization, SerializationFormat}
 import scala.collection.mutable.{ArrayBuffer, HashMap}
 import ohnosequences.files.{read, write, Lines, File, Error => FileError}
 
 case object io {
 
   import StringUtils._
+
+  val defaultFormat: SerializationFormat = SerializationFormat(";;;", "///")
 
   private final case class RankMap(
       root: Option[IdWithRank],
@@ -28,7 +31,7 @@ case object io {
 
     val nodes = parse.nodes.fromLines(nodesLines)
 
-    /* 
+    /*
      Find root while looping through the nodes, where
      the root is the node whose parent and id are the same
 
@@ -123,8 +126,8 @@ case object io {
   }
 
   def treeMapToTaxTree(tree: TreeMap): TaxTree = {
-    val root        = tree.root
-    val children    = tree.children
+    val root     = tree.root
+    val children = tree.children
     // Generator. Let's keep in mind that root of the tree is TaxID 1
     val init: TaxID = -1
 
@@ -173,7 +176,7 @@ case object io {
       shapeFile: File
   ): FileError + (File, File) = {
 
-    val format = treeIO.defaultFormat
+    val format = defaultFormat
 
     val serialization = treeIO.serializeTree(tree, format)
     // data and shape are numberedLines, we need to map them to
@@ -216,10 +219,10 @@ case object io {
       read.withLines(shapeFile) { shapeLines =>
         val shape = shapeLines.zipWithIndex
 
-        val serialization = treeIO.Serialization(
+        val serialization = Serialization(
           data,
           shape,
-          treeIO.defaultFormat
+          defaultFormat
         )
 
         val tree = treeIO.deserializeTree(

--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -33,5 +33,11 @@ package object ncbitaxonomy {
   def nodes(version: Version): S3Object =
     s3Prefix(version)("nodes.dmp")
 
+  def treeData(version: Version): S3Object =
+    s3Prefix(version)("data.tree")
+
+  def treeShape(version: Version): S3Object =
+    s3Prefix(version)("shape.tree")
+
   val hashingFunction: DigestFunction = DigestFunction.SHA512
 }

--- a/src/test/scala/checkFullTaxonomy.scala
+++ b/src/test/scala/checkFullTaxonomy.scala
@@ -4,8 +4,10 @@ import scala.collection.mutable.HashSet
 import ohnosequences.db.ncbitaxonomy._
 import ohnosequences.db
 import ohnosequences.test.ReleaseOnlyTest
+import org.scalatest.DoNotDiscover
 
-class ParseFullTaxonomy extends NCBITaxonomyTest("ParseFullTaxonomy") {
+@DoNotDiscover
+class CheckFullTaxonomy extends NCBITaxonomyTest("ParseFullTaxonomy") {
 
   test("Parse all names and access all data", ReleaseOnlyTest) {
 
@@ -112,7 +114,7 @@ class ParseFullTaxonomy extends NCBITaxonomyTest("ParseFullTaxonomy") {
       val shapeData = getTreeShapeFile(version)
       val numNodes  = readLinesWith(getNodesFile(version)) { _.length }
 
-      val tree = generateTree(treeData, shapeData)
+      val tree = readTreeFrom(treeData, shapeData)
 
       assert { tree.numNodes == numNodes }
     }

--- a/src/test/scala/checkOldVersions.scala
+++ b/src/test/scala/checkOldVersions.scala
@@ -1,10 +1,10 @@
 package ohnosequences.db.ncbitaxonomy.test
 
-import ohnosequences.db.ncbitaxonomy.{Version, names, nodes}
+import ohnosequences.db.ncbitaxonomy._
 
 class CheckOldVersions extends NCBITaxonomyTest("CheckOldVersions") {
 
-  test("S3 objects (nodes and names) exist for all versions") {
+  test("nodes.dmp and names.dmp exist in S3 for all versions") {
 
     val versionObjects =
       Version.all map { version =>
@@ -17,6 +17,24 @@ class CheckOldVersions extends NCBITaxonomyTest("CheckOldVersions") {
           println(s"S3 objects exist: ${version.name}")
           objectExists(namesObj) &&
           objectExists(nodesObj)
+      }
+    }
+  }
+
+  test(
+    "data.tree and shape.tree exist in S3 for all versions. If not, create them") {
+
+    val versionObjects =
+      Version.all map { version =>
+        (version, treeData(version), treeShape(version))
+      }
+
+    assert {
+      versionObjects forall {
+        case (version, treeData, treeShape) =>
+          println(s"S3 objects exist: ${version.name}")
+          objectExists(treeData) &&
+          objectExists(treeShape)
       }
     }
   }

--- a/src/test/scala/checkOldVersions.scala
+++ b/src/test/scala/checkOldVersions.scala
@@ -23,7 +23,7 @@ class CheckOldVersions extends NCBITaxonomyTest("CheckOldVersions") {
   }
 
   test(
-    "data.tree and shape.tree exist in S3 for all versions. If not, create them") {
+    "data.tree and shape.tree exist in S3 for all versions") {
 
     val versionObjects =
       Version.all map { version =>

--- a/src/test/scala/checkOldVersions.scala
+++ b/src/test/scala/checkOldVersions.scala
@@ -1,7 +1,9 @@
 package ohnosequences.db.ncbitaxonomy.test
 
 import ohnosequences.db.ncbitaxonomy._
+import org.scalatest.DoNotDiscover
 
+@DoNotDiscover
 class CheckOldVersions extends NCBITaxonomyTest("CheckOldVersions") {
 
   test("nodes.dmp and names.dmp exist in S3 for all versions") {
@@ -11,13 +13,12 @@ class CheckOldVersions extends NCBITaxonomyTest("CheckOldVersions") {
         (version, names(version), nodes(version))
       }
 
-    assert {
-      versionObjects forall {
-        case (version, namesObj, nodesObj) =>
-          println(s"S3 objects exist: ${version.name}")
-          objectExists(namesObj) &&
-          objectExists(nodesObj)
-      }
+    versionObjects foreach {
+      case (version, namesObj, nodesObj) =>
+        assert(
+          objectExists(namesObj) && objectExists(nodesObj),
+          s"S3 objects names.dmp and nodes.dmp do not exist for version ${version.name}"
+        )
     }
   }
 
@@ -29,13 +30,12 @@ class CheckOldVersions extends NCBITaxonomyTest("CheckOldVersions") {
         (version, treeData(version), treeShape(version))
       }
 
-    assert {
-      versionObjects forall {
-        case (version, treeData, treeShape) =>
-          println(s"S3 objects exist: ${version.name}")
-          objectExists(treeData) &&
-          objectExists(treeShape)
-      }
+    versionObjects foreach {
+      case (version, treeData, treeShape) =>
+        assert(
+          objectExists(treeData) && objectExists(treeShape),
+          s"S3 objects data.tree and shape.tree do not exist for version ${version.name}"
+        )
     }
   }
 }

--- a/src/test/scala/data.scala
+++ b/src/test/scala/data.scala
@@ -1,8 +1,48 @@
 package ohnosequences.db.ncbitaxonomy.test
 
-import ohnosequences.db.ncbitaxonomy.Version
+import ohnosequences.db.ncbitaxonomy._, io.defaultFormat
+import ohnosequences.forests.{NonEmptyTree, random}
+import scala.collection.mutable.StringBuilder
+import java.io.File.createTempFile
 
 object data {
+  import Rank._
+
+  val numInstances: Int         = 100
+  val maxDepth: Int             = 10
+  val maxSiblingsPerFamily: Int = 5
+  val allRanks: Array[Rank] = Array(
+    Superkingdom,
+    Kingdom,
+    Subkingdom,
+    Superphylum,
+    Phylum,
+    Subphylum,
+    Superclass,
+    Class,
+    Subclass,
+    Infraclass,
+    Cohort,
+    Superorder,
+    Order,
+    Suborder,
+    Infraorder,
+    Parvorder,
+    Superfamily,
+    Family,
+    Subfamily,
+    Tribe,
+    Subtribe,
+    Genus,
+    Subgenus,
+    SpeciesGroup,
+    SpeciesSubgroup,
+    Species,
+    Subspecies,
+    Varietas,
+    Forma,
+    NoRank
+  )
 
   def dataDirectory(version: Version): File =
     new File(s"./data/in/${version.name}")
@@ -18,4 +58,56 @@ object data {
 
   def treeShapeLocalFile(version: Version): File =
     dataDirectory(version).toPath.resolve("shape.tree").toFile
+
+  // Random tax trees
+  val taxTrees: Array[TaxTree] = {
+    def nextString: String = {
+      val length      = random.intIn(0, 100)
+      val siblingsSep = defaultFormat.siblingsSep
+      val familySep   = defaultFormat.familySep
+
+      @annotation.tailrec
+      def fill(result: StringBuilder, i: Int): String =
+        if (i < length) {
+          // Readable chars
+          val randomChar = random.intIn(32, 127).toChar
+          fill(result.append(randomChar), i + 1)
+        } else {
+          // Assume ;;; and /// cannot appear in a node description
+          result.toString
+            .replaceAll(siblingsSep, "")
+            .replaceAll(familySep, "")
+        }
+
+      fill(new StringBuilder, 0)
+    }
+
+    val numRanks = allRanks.length
+
+    def nextRank: Rank = {
+      val toPick = random.intIn(0, numRanks)
+      allRanks(toPick)
+    }
+
+    def nextTaxNode: TaxNode =
+      TaxNode(random.intIn(0, 10), nextRank, nextString)
+
+    Array.tabulate(numInstances) { i =>
+      val forestDepth = random.intIn(0, maxDepth + 1)
+      val children =
+        random.genForest(_ => nextTaxNode, forestDepth, maxSiblingsPerFamily)
+      val root = nextTaxNode
+
+      new NonEmptyTree(root, children)
+    }
+  }
+
+  val dataTempFile: Array[File] = Array.tabulate(numInstances) { i =>
+    createTempFile(s"treeData-${i}", ".tmp")
+  }
+
+  val shapeTempFile: Array[File] = Array.tabulate(numInstances) { i =>
+    createTempFile(s"treeShape-${i}", ".tmp")
+  }
+
 }

--- a/src/test/scala/data.scala
+++ b/src/test/scala/data.scala
@@ -9,4 +9,10 @@ object data {
 
   def nodesLocalFile(version: Version): File =
     new File(s"./data/in/${version}/nodes.dmp")
+
+  def treeDataLocalFile(version: Version): File =
+    new File(s"./data/in/${version}/data.tree")
+
+  def treeShapeLocalFile(version: Version): File =
+    new File(s"./data/in/${version}/shape.tree")
 }

--- a/src/test/scala/data.scala
+++ b/src/test/scala/data.scala
@@ -5,7 +5,7 @@ import ohnosequences.db.ncbitaxonomy.Version
 object data {
 
   def dataDirectory(version: Version): File =
-    new File(s"./data/in/${version}")
+    new File(s"./data/in/${version.name}")
 
   def namesLocalFile(version: Version): File =
     dataDirectory(version).toPath.resolve("names.dmp").toFile

--- a/src/test/scala/data.scala
+++ b/src/test/scala/data.scala
@@ -4,15 +4,18 @@ import ohnosequences.db.ncbitaxonomy.Version
 
 object data {
 
+  def dataDirectory(version: Version): File =
+    new File(s"./data/in/${version}")
+
   def namesLocalFile(version: Version): File =
-    new File(s"./data/in/${version}/names.dmp")
+    dataDirectory(version).toPath.resolve("names.dmp").toFile
 
   def nodesLocalFile(version: Version): File =
-    new File(s"./data/in/${version}/nodes.dmp")
+    dataDirectory(version).toPath.resolve("nodes.dmp").toFile
 
   def treeDataLocalFile(version: Version): File =
-    new File(s"./data/in/${version}/data.tree")
+    dataDirectory(version).toPath.resolve("data.tree").toFile
 
   def treeShapeLocalFile(version: Version): File =
-    new File(s"./data/in/${version}/shape.tree")
+    dataDirectory(version).toPath.resolve("shape.tree").toFile
 }

--- a/src/test/scala/io.scala
+++ b/src/test/scala/io.scala
@@ -1,0 +1,20 @@
+package ohnosequences.db.ncbitaxonomy.test
+
+class TreeDump extends NCBITaxonomyTest("TreeDump") {
+
+  test("readTreeFrom ∘ dumpTreeTo == id") {
+
+    data.taxTrees.zipWithIndex foreach {
+      case (tree, i) =>
+        val (dataFile, shapeFile) = dumpTreeTo(
+          tree,
+          data.dataTempFile(i),
+          data.shapeTempFile(i)
+        )
+        val result = readTreeFrom(dataFile, shapeFile)
+
+        assert { tree == result }
+    }
+  }
+
+}

--- a/src/test/scala/mirror.scala
+++ b/src/test/scala/mirror.scala
@@ -2,6 +2,7 @@ package ohnosequences.db.ncbitaxonomy.test
 
 import ohnosequences.db.ncbitaxonomy._
 import ohnosequences.test.ReleaseOnlyTest
+import ohnosequences.files.utils.checkValidFile
 
 class Mirror extends NCBITaxonomyTest("Mirror") {
 
@@ -9,40 +10,63 @@ class Mirror extends NCBITaxonomyTest("Mirror") {
 
     val version = Version.latest
 
-    val directory = new File(s"./ncbi-data/${version.name}")
+    val tempDir = new File(s"./ncbi-data/${version.name}")
+    val dataDir = data.dataDirectory(version)
 
-    val localFile     = directory.toPath.resolve("taxdump.tar.gz").toFile
-    val nodesFile     = directory.toPath.resolve("nodes.dmp").toFile
-    val namesFile     = directory.toPath.resolve("names.dmp").toFile
-    val treeDataFile  = directory.toPath.resolve("data.tree").toFile
-    val treeShapeFile = directory.toPath.resolve("shape.tree").toFile
+    val tempTarFile   = tempDir.toPath.resolve("taxdump.tar.gz").toFile
+    val nodesTempFile = tempDir.toPath.resolve("nodes.dmp").toFile
+    val namesTempFile = tempDir.toPath.resolve("names.dmp").toFile
 
-    // Create the relative directory
-    createDirectory(directory)
+    // Create a temp directory to uncompress and untar files from NCBI
+    createDirectory(tempDir)
 
     // Retrieve original archived, compressed file from NCBI FTP
-    downloadFromURL(sourceFile, localFile)
+    downloadFromURL(sourceFile, tempTarFile)
 
     // Uncompress and extract the archive file to get names.dmp and nodes.dmp
-    uncompressAndExtractTo(localFile, directory)
+    uncompressAndExtractTo(tempTarFile, tempDir)
 
+    val nodesFile = move(nodesTempFile, dataDir)
+    val namesFile = move(namesTempFile, dataDir)
+
+    // Delete temp dir
+    recursiveDeleteDirectory(tempDir)
+
+    // Get names of objects in S3
     val namesObj = names(version)
     val nodesObj = nodes(version)
-    val dataObj  = treeData(version)
-    val shapeObj = treeShape(version)
-    
+
     // Upload nodes.dmp and names.dmp to their respective S3 locations,
     // only if those objects do not exist.
     uploadIfNotExists(namesFile, namesObj)
     uploadIfNotExists(nodesFile, nodesObj)
-
-    // Generate taxonomy tree and upload data.tree and shape.tree to S3, if they
-    // do not exist
-    val tree = generateTree(nodesFile, namesFile)
-    dumpTaxTreeTo(tree, treeDataFile, treeShapeFile)
-
-    uploadIfNotExists(treeDataFile, dataObj)
-    uploadIfNotExists(treeShapeFile, shapeObj)
   }
 
+  test("Mirror trees for all versions, if they do not exist", ReleaseOnlyTest) {
+    Version.all foreach { version =>
+      val dataObj  = treeData(version)
+      val shapeObj = treeShape(version)
+
+      if (!objectExists(dataObj) || !objectExists(shapeObj)) {
+        val dataFile  = getTreeDataFile(version)
+        val shapeFile = getTreeShapeFile(version)
+
+        if (!dataFile.exists || !shapeFile.exists) {
+          deleteFile(dataFile)
+          deleteFile(shapeFile)
+
+          val nodesFile = getNodesFile(version)
+          val namesFile = getNamesFile(version)
+
+          // Generate taxonomy tree and upload data.tree and shape.tree to S3, if they
+          // do not exist
+          val tree = generateTree(nodesFile, namesFile)
+          dumpTreeTo(tree, dataFile, shapeFile)
+        }
+
+        uploadIfNotExists(dataFile, dataObj)
+        uploadIfNotExists(shapeFile, shapeObj)
+      }
+    }
+  }
 }

--- a/src/test/scala/mirror.scala
+++ b/src/test/scala/mirror.scala
@@ -3,43 +3,66 @@ package ohnosequences.db.ncbitaxonomy.test
 import ohnosequences.db.ncbitaxonomy._
 import ohnosequences.test.ReleaseOnlyTest
 import ohnosequences.files.utils.checkValidFile
+import org.scalatest.DoNotDiscover
 
+@DoNotDiscover
 class Mirror extends NCBITaxonomyTest("Mirror") {
 
   test("Mirror data from NCBI FTP into ohnosequences S3", ReleaseOnlyTest) {
 
     val version = Version.latest
 
-    val tempDir = new File(s"./ncbi-data/${version.name}")
-    val dataDir = data.dataDirectory(version)
-
-    val tempTarFile   = tempDir.toPath.resolve("taxdump.tar.gz").toFile
-    val nodesTempFile = tempDir.toPath.resolve("nodes.dmp").toFile
-    val namesTempFile = tempDir.toPath.resolve("names.dmp").toFile
-
-    // Create a temp directory to uncompress and untar files from NCBI
-    createDirectory(tempDir)
-
-    // Retrieve original archived, compressed file from NCBI FTP
-    downloadFromURL(sourceFile, tempTarFile)
-
-    // Uncompress and extract the archive file to get names.dmp and nodes.dmp
-    uncompressAndExtractTo(tempTarFile, tempDir)
-
-    val nodesFile = move(nodesTempFile, dataDir)
-    val namesFile = move(namesTempFile, dataDir)
-
-    // Delete temp dir
-    recursiveDeleteDirectory(tempDir)
-
     // Get names of objects in S3
     val namesObj = names(version)
     val nodesObj = nodes(version)
 
-    // Upload nodes.dmp and names.dmp to their respective S3 locations,
-    // only if those objects do not exist.
-    uploadIfNotExists(namesFile, namesObj)
-    uploadIfNotExists(nodesFile, nodesObj)
+    // If S3 objects for {names, nodes}.dmp do not exist,
+    // download NCBI files and mirror them
+    if (!objectExists(namesObj) || !objectExists(nodesObj)) {
+
+      val nodesFile = data.nodesLocalFile(version)
+      val namesFile = data.namesLocalFile(version)
+
+      if (!nodesFile.exists || !namesFile.exists) {
+        // If any of them does not exists, regenerate them
+        deleteFile(nodesFile)
+        deleteFile(namesFile)
+
+        val tempDir = new File(s"./ncbi-data/${version.name}")
+        val dataDir = data.dataDirectory(version)
+
+        val tempTarFile   = tempDir.toPath.resolve("taxdump.tar.gz").toFile
+        val nodesTempFile = tempDir.toPath.resolve("nodes.dmp").toFile
+        val namesTempFile = tempDir.toPath.resolve("names.dmp").toFile
+
+        // Clean and create a temp directory to uncompress and untar files from NCBI
+        if (tempDir.exists)
+          recursiveDeleteDirectory(tempDir)
+
+        createDirectory(tempDir)
+
+        // Retrieve original archived, compressed file from NCBI FTP
+        downloadFromURL(sourceFile, tempTarFile)
+
+        // Uncompress and extract the archive file to get names.dmp and nodes.dmp
+        uncompressAndExtractTo(tempTarFile, tempDir)
+
+        // Create directory for data if it does not exists
+        if (!dataDir.exists)
+          createDirectory(dataDir)
+
+        move(nodesTempFile, dataDir)
+        move(namesTempFile, dataDir)
+
+        // Delete temp dir
+        recursiveDeleteDirectory(tempDir)
+
+        // Upload nodes.dmp and names.dmp to their respective S3 locations,
+        // only if those objects do not exist.
+        uploadIfNotExists(namesFile, namesObj)
+        uploadIfNotExists(nodesFile, nodesObj)
+      }
+    }
   }
 
   test("Mirror trees for all versions, if they do not exist", ReleaseOnlyTest) {
@@ -47,11 +70,15 @@ class Mirror extends NCBITaxonomyTest("Mirror") {
       val dataObj  = treeData(version)
       val shapeObj = treeShape(version)
 
+      // If either data or shape for the taxonomic tree do not exist
+      // in S3, regenerate them and mirror them
       if (!objectExists(dataObj) || !objectExists(shapeObj)) {
-        val dataFile  = getTreeDataFile(version)
-        val shapeFile = getTreeShapeFile(version)
+        // Search for the data and shape files locally
+        val dataFile  = data.treeDataLocalFile(version)
+        val shapeFile = data.treeShapeLocalFile(version)
 
         if (!dataFile.exists || !shapeFile.exists) {
+          // If any of them does not exists, regenerate them
           deleteFile(dataFile)
           deleteFile(shapeFile)
 

--- a/src/test/scala/mirrorAndCheck.scala
+++ b/src/test/scala/mirrorAndCheck.scala
@@ -1,0 +1,11 @@
+package ohnosequences.db.ncbitaxonomy.test
+
+import org.scalatest.{CancelAfterFailure, Suites}
+
+class MirrorAndCheck
+    extends Suites(
+      // Ensure mirroring before checking files
+      new Mirror,
+      new CheckOldVersions,
+      new CheckFullTaxonomy
+    )

--- a/src/test/scala/testClasses.scala
+++ b/src/test/scala/testClasses.scala
@@ -1,6 +1,9 @@
 package ohnosequences.db.ncbitaxonomy.test
+import org.scalatest.{CancelAfterFailure, FunSuite}
 
-class NCBITaxonomyTest(val name: String) extends org.scalatest.FunSuite {
+class NCBITaxonomyTest(val name: String)
+    extends FunSuite
+    with CancelAfterFailure {
 
   override final val suiteName: String =
     s"NCBI Taxonomy - ${name}"


### PR DESCRIPTION
Code for writing and reading taxonomy trees to files.

Also this PR adds generation of trees to the mirroring of files, and a better ordering of tests, so that mirroring is performed before checking taxonomy files are OK.

I will add documentation in a separate PR.

Right now it is expected that tests do not compile since we need an in-cascade releasing process for all descendants of `files` package: `files`, `forests` and`s3`