### PR TITLE
Add a list of ranks ordered by increasing specificity

### DIFF
--- a/notes/0.2.1.markdown
+++ b/notes/0.2.1.markdown
@@ -1,0 +1,7 @@
+# 0.2.0
+
+This bugfix release adds an ordered list of ranks in
+
+```
+ohnosequences.db.ncbitaxonomy.Rank.orderedList
+```

--- a/notes/0.2.1.markdown
+++ b/notes/0.2.1.markdown
@@ -1,4 +1,4 @@
-# 0.2.0
+# 0.2.1
 
 This bugfix release adds an ordered list of ranks in
 

--- a/src/main/scala/rank.scala
+++ b/src/main/scala/rank.scala
@@ -35,8 +35,9 @@ case object Rank {
   case object Forma           extends Rank
   case object NoRank          extends Rank
 
-  /** All the possible ranks */
-  val all: Set[Rank] = Set(
+  /** A list of all the meaningful ranks (all but NoRank), ordered by
+  increasing specificity **/
+  val orderedList: List[Rank] = List[Rank](
     Superkingdom,
     Kingdom,
     Subkingdom,
@@ -65,9 +66,11 @@ case object Rank {
     Species,
     Subspecies,
     Varietas,
-    Forma,
-    NoRank
+    Forma
   )
+
+  /** All the possible ranks */
+  val all: Set[Rank] = orderedList.toSet + NoRank
 
   /** Returns, if it is possible to parse it, a `Rank` from a `String`
     *


### PR DESCRIPTION
Just as the title says. All tests passing, so I'm directly merging this to use it in https://github.com/ohnosequences/db.taxonomy/pull/20